### PR TITLE
Add Raspberry Pi control script

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,22 @@ This repository contains a modular set of applications built to leverage the per
 ```bash
 git clone https://github.com/your-username/pi5-software-suite.git
 cd pi5-software-suite
+npm install
+```
+
+### Node.js Control Script
+
+After installing dependencies, you can run the command-line utility:
+
+```bash
+node pi_controller.js --help
+```
+
+This script provides several commands for interacting with Raspberry Pi hardware:
+
+- `gpio <pin> <value>`: Set a GPIO pin high or low.
+- `read-dht <type> <pin>`: Read temperature and humidity from a DHT sensor.
+- `i2c-scan`: Scan the I2C bus for connected devices.
+- `capture <file>`: Capture a photo using the Pi camera.
+
+Each command can be invoked using `node pi_controller.js <command>` or after global installation with `npm install -g .` by calling `pi-controller` directly.

--- a/README.md
+++ b/README.md
@@ -68,3 +68,15 @@ This script provides several commands for interacting with Raspberry Pi hardware
 - `capture <file>`: Capture a photo using the Pi camera.
 
 Each command can be invoked using `node pi_controller.js <command>` or after global installation with `npm install -g .` by calling `pi-controller` directly.
+
+### Simulation Mode
+
+If you want to test the CLI without Raspberry Pi hardware or external Node.js dependencies, use the `pi_simulator.js` script instead. This script emulates the output of the hardware commands.
+
+Example:
+
+```bash
+node pi_simulator.js gpio 17 1
+```
+
+The simulator will print messages describing the actions it would perform.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "pi-apps",
+  "version": "1.0.0",
+  "description": "Raspberry Pi control CLI",
+  "main": "pi_controller.js",
+  "bin": {
+    "pi-controller": "./pi_controller.js"
+  },
+  "dependencies": {
+    "commander": "^10.0.0",
+    "i2c-bus": "^5.2.2",
+    "node-dht-sensor": "^0.4.3",
+    "onoff": "^6.0.0"
+  }
+}

--- a/pi_controller.js
+++ b/pi_controller.js
@@ -1,0 +1,64 @@
+const { Command } = require('commander');
+const { Gpio } = require('onoff');
+const i2c = require('i2c-bus');
+const sensor = require('node-dht-sensor').promises;
+const { exec } = require('child_process');
+
+const program = new Command();
+program
+  .name('pi-controller')
+  .description('Raspberry Pi control CLI');
+
+program
+  .command('gpio <pin> <value>')
+  .description('Set a GPIO pin high or low')
+  .action((pin, value) => {
+    const out = new Gpio(Number(pin), 'out');
+    out.writeSync(value === '1' ? 1 : 0);
+    out.unexport();
+  });
+
+program
+  .command('read-dht <type> <pin>')
+  .description('Read temperature and humidity from a DHT sensor')
+  .action(async (type, pin) => {
+    try {
+      const res = await sensor.read(Number(type), Number(pin));
+      console.log(`Temp: ${res.temperature.toFixed(1)}\u00B0C`);
+      console.log(`Humidity: ${res.humidity.toFixed(1)}%`);
+    } catch (err) {
+      console.error('Failed to read sensor', err);
+    }
+  });
+
+program
+  .command('i2c-scan')
+  .description('Scan I2C bus for devices')
+  .action(() => {
+    const bus = i2c.openSync(1);
+    console.log('Scanning I2C bus 1...');
+    for (let addr = 0x03; addr <= 0x77; addr++) {
+      try {
+        bus.receiveByteSync(addr);
+        console.log(`Device found at 0x${addr.toString(16)}`);
+      } catch {
+        // ignore errors when no device responds
+      }
+    }
+    bus.closeSync();
+  });
+
+program
+  .command('capture <file>')
+  .description('Capture a photo with raspistill')
+  .action((file) => {
+    exec(`raspistill -o ${file}`, (err) => {
+      if (err) {
+        console.error('Capture failed', err);
+        return;
+      }
+      console.log(`Image saved to ${file}`);
+    });
+  });
+
+program.parse(process.argv);

--- a/pi_simulator.js
+++ b/pi_simulator.js
@@ -1,0 +1,44 @@
+const args = process.argv.slice(2);
+const command = args[0];
+
+switch (command) {
+  case 'gpio':
+    if (args.length < 3) {
+      console.log('Usage: gpio <pin> <value>');
+      break;
+    }
+    console.log(`[SIMULATION] Setting GPIO pin ${args[1]} to ${args[2]}`);
+    break;
+
+  case 'read-dht':
+    if (args.length < 3) {
+      console.log('Usage: read-dht <type> <pin>');
+      break;
+    }
+    console.log(`[SIMULATION] Reading DHT type ${args[1]} on pin ${args[2]}`);
+    console.log('[SIMULATION] Temperature: 22.5\u00B0C');
+    console.log('[SIMULATION] Humidity: 50%');
+    break;
+
+  case 'i2c-scan':
+    console.log('[SIMULATION] Scanning I2C bus 1...');
+    console.log('[SIMULATION] Device found at 0x3c');
+    console.log('[SIMULATION] Device found at 0x40');
+    break;
+
+  case 'capture':
+    if (args.length < 2) {
+      console.log('Usage: capture <file>');
+      break;
+    }
+    console.log(`[SIMULATION] Capturing image to ${args[1]}`);
+    break;
+
+  default:
+    console.log('Usage: node pi_simulator.js <command>');
+    console.log('Commands:');
+    console.log('  gpio <pin> <value>');
+    console.log('  read-dht <type> <pin>');
+    console.log('  i2c-scan');
+    console.log('  capture <file>');
+}


### PR DESCRIPTION
## Summary
- add a Node.js script (`pi_controller.js`) that exposes GPIO, I2C, DHT sensor, and camera commands
- introduce `package.json` with required dependencies and bin setup
- update `README.md` with usage instructions for the control script

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684e9ee52b748324a935c9ee099f9207